### PR TITLE
Use /bin/bash to support brace expansion

### DIFF
--- a/common/Makefrag
+++ b/common/Makefrag
@@ -4,6 +4,7 @@ JOBS = 16
 base_dir = $(abspath ..)
 common = $(base_dir)/common
 output_delivery = deliver_output
+SHELL := /bin/bash
 
 ifneq ($(BOARD_MODEL),)
 	insert_board = s/\# REPLACE FOR OFFICIAL BOARD NAME/set_property "board_part" "$(BOARD_MODEL)"/g


### PR DESCRIPTION
The brace expansion used by `cp` in the `rocket` target barfs if the shell isn't set to `bash`.